### PR TITLE
switch to non-damageable slot if current tool has same harvest speed

### DIFF
--- a/src/main/java/duelmonster/superminer/submods/Substitutor.java
+++ b/src/main/java/duelmonster/superminer/submods/Substitutor.java
@@ -192,11 +192,11 @@ public class Substitutor {
 			ItemStack[] inventory = mc.thePlayer.inventory.mainInventory;
 			
 			// Abort Substitution if the current Item is valid for the attacking block
-			if (SettingsSubstitutor.bIgnoreIfValidTool
+			/*if (SettingsSubstitutor.bIgnoreIfValidTool
 				&& mc.thePlayer.getHeldItemMainhand() != null
 				&& mc.thePlayer.getHeldItemMainhand().canHarvestBlock(world.getBlockState(oPos)))
-				return;
-	
+				return;*/
+
 			for (int i = 0; i < 9; i++) {
 				if (i == iSubstitueTool) continue;
 				
@@ -219,7 +219,7 @@ public class Substitutor {
 			
 		} catch (Throwable e) {
 			//throwException("Error switching weapons", e, false);
-			System.out.println("Error switching weapons - " + e.getMessage());
+			System.out.println("Error switching tools - " + e.getMessage());
 		}
 	}
 	
@@ -267,8 +267,12 @@ public class Substitutor {
 
 		float currentDigSpeed = SubstitutionHelper.getDigSpeed(CurrentTool, state);
 		float compareDigSpeed = SubstitutionHelper.getDigSpeed(CompareTool, state);
-
-		if (compareDigSpeed > currentDigSpeed) return true;
+		
+		boolean currentToolDamageable = SubstitutionHelper.isItemStackDamageable(CurrentTool);
+		boolean compareToolDamageable = SubstitutionHelper.isItemStackDamageable(CompareTool);
+		
+		if (currentToolDamageable && !compareToolDamageable && compareDigSpeed >= currentDigSpeed) return true;
+		else if (compareDigSpeed >= currentDigSpeed) return true;
 		else if (compareDigSpeed < currentDigSpeed) return false;
 
 		if (SettingsSubstitutor.bFavourSilkTouch) {
@@ -301,8 +305,8 @@ public class Substitutor {
 			else if (compareLevel < currentLevel) return false;
 		}
 
-		boolean currentToolDamageable = SubstitutionHelper.isItemStackDamageable(CurrentTool);
-		boolean compareToolDamageable = SubstitutionHelper.isItemStackDamageable(CompareTool);
+		//boolean currentToolDamageable = SubstitutionHelper.isItemStackDamageable(CurrentTool);
+		//boolean compareToolDamageable = SubstitutionHelper.isItemStackDamageable(CompareTool);
 		
 //		if (compareToolDamageable && !currentToolDamageable) return false;
 //		else if (currentToolDamageable && !compareToolDamageable) return true;


### PR DESCRIPTION
This keeps you from using a tool for unintended purposes that wastes
durability